### PR TITLE
generate-krb5-conf: fix use of config/krb5.conf

### DIFF
--- a/tests/data/generate-krb5-conf
+++ b/tests/data/generate-krb5-conf
@@ -67,7 +67,7 @@ awk '
     !/^ *\[appdefaults\]/ && / *\[/   { skip = 0 }
 
     { if (skip == 0) print }
-' "$p" > tmp/krb5.conf.tmp
+' "$krb5conf" > tmp/krb5.conf.tmp
 if [ -n "$realm" ] ; then
     sed -e "s/\\(default_realm.*=\\) .*/\\1 $realm/" \
         tmp/krb5.conf.tmp > tmp/krb5.conf


### PR DESCRIPTION
When krb5.conf is present in the config directory, actually use it.
Without this change, we end up passing no filename at all, and awk
tries to read it from stdin.