### PR TITLE
Ignore -Wformat-truncation for GCC 7 and later

### DIFF
--- a/portable/getnameinfo.c
+++ b/portable/getnameinfo.c
@@ -176,16 +176,16 @@ lookup_service(unsigned short port, char *service, socklen_t servicelen,
     /*
      * Just convert the port number to ASCII.  Suppress warnings here because
      * GCC 10 isn't smart enough to realize that the return status is checked
-     * for truncation.
+     * for truncation, a GCC warning introduced in GCC 7.
      */
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wformat-truncation"
 #endif
     status = snprintf(service, servicelen, "%hu", port);
     if (status < 0 || (socklen_t) status >= servicelen)
         return EAI_OVERFLOW;
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__)
 #    pragma GCC diagnostic pop
 #endif
     return 0;


### PR DESCRIPTION
When using GCC 6 or earlier, the pragma is not recognized and leads to a warning.