### PR TITLE
cc-flags.m4: Make last AS_CASE pattern the default

### DIFF
--- a/m4/cc-flags.m4
+++ b/m4/cc-flags.m4
@@ -15,7 +15,7 @@ dnl
 dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
-dnl Copyright 2016-2021 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2016-2022 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2006, 2009, 2016
 dnl     by Internet Systems Consortium, Inc. ("ISC")
 dnl
@@ -50,7 +50,7 @@ AC_DEFUN([RRA_PROG_CC_FLAG],
         [CFLAGS="$CFLAGS -Werror=unknown-warning-option"])
      AS_CASE([$1],
         [-Wno-*], [CFLAGS="$CFLAGS `AS_ECHO(["$1"]) | sed 's/-Wno-/-W/'`"],
-        [*],      [CFLAGS="$CFLAGS $1"])
+        [CFLAGS="$CFLAGS $1"])
      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [int foo = 0;])],
         [_RRA_PROG_CC_FLAG_CACHE([$1])=yes],
         [_RRA_PROG_CC_FLAG_CACHE([$1])=no])


### PR DESCRIPTION
AS_CASE does not need a "[*]" pattern, as the last argument is the default. Otherwise, Autoconf writes 2 defaults in the shell output:

  *) :
    CFLAGS="$CFLAGS -Wno-extra" ;; #(
  *) :
     ;;