### PR TITLE
Generalize the use of -isystem instead of -I

### DIFF
--- a/m4/apache.m4
+++ b/m4/apache.m4
@@ -18,7 +18,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
-dnl Copyright 2021 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2021, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2010
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -80,7 +80,7 @@ AC_DEFUN([RRA_LIB_APACHE],
  rra_apache_includedir=`"$rra_apache_apxs" -q INCLUDEDIR 2>/dev/null`
  AS_IF([test -z "$rra_apache_includedir"],
     [AC_MSG_ERROR([apxs -q INCLUDEDIR failed or returned no value])])
- APACHE_CPPFLAGS="$APACHE_CPPFLAGS -I$rra_apache_includedir"
+ APACHE_CPPFLAGS="$APACHE_CPPFLAGS -isystem $rra_apache_includedir"
  AC_ARG_VAR([APR_CONFIG], [Path to apr-1-config or apr-config])
  AC_PATH_PROGS([APR_CONFIG], [apr-1-config apr-config], [false])
  AS_IF([test x"$APR_CONFIG" != xfalse],

--- a/m4/apr.m4
+++ b/m4/apr.m4
@@ -18,6 +18,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2010-2011
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -53,10 +54,10 @@ AC_DEFUN([_RRA_LIB_APR_PATHS],
     [AS_IF([test x"$rra_apr_root" != x],
         [RRA_SET_LDFLAGS([APR_LDFLAGS], [$rra_apr_root])])])
  AS_IF([test x"$rra_apr_includedir" != x],
-    [APR_CPPFLAGS="-I$rra_apr_includedir"],
+    [APR_CPPFLAGS="-isystem $rra_apr_includedir"],
     [AS_IF([test x"$rra_apr_root" != x],
         [AS_IF([test x"$rra_apr_root" != x/usr],
-            [APR_CPPFLAGS="-I${rra_apr_root}/include"])])])])
+            [APR_CPPFLAGS="-isystem ${rra_apr_root}/include"])])])])
 
 dnl The main macro for determining the flags for Apache modules.
 AC_DEFUN([RRA_LIB_APR],

--- a/m4/aprutil.m4
+++ b/m4/aprutil.m4
@@ -19,6 +19,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2010-2011
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -54,10 +55,10 @@ AC_DEFUN([_RRA_LIB_APRUTIL_PATHS],
     [AS_IF([test x"$rra_aprutil_root" != x],
         [RRA_SET_LDFLAGS([APRUTIL_LDFLAGS], [$rra_aprutil_root])])])
  AS_IF([test x"$rra_aprutil_includedir" != x],
-    [APRUTIL_CPPFLAGS="-I$rra_aprutil_includedir"],
+    [APRUTIL_CPPFLAGS="-isystem $rra_aprutil_includedir"],
     [AS_IF([test x"$rra_aprutil_root" != x],
         [AS_IF([test x"$rra_aprutil_root" != x/usr],
-            [APRUTIL_CPPFLAGS="-I${rra_aprutil_root}/include"])])])])
+            [APRUTIL_CPPFLAGS="-isystem ${rra_aprutil_root}/include"])])])])
 
 dnl The main macro for determining the flags for Apache modules.
 AC_DEFUN([RRA_LIB_APRUTIL],

--- a/m4/curl.m4
+++ b/m4/curl.m4
@@ -20,7 +20,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
-dnl Copyright 2021 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2021, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2010, 2013
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -56,10 +56,10 @@ AC_DEFUN([_RRA_LIB_CURL_PATHS],
     [AS_IF([test x"$rra_curl_root" != x],
         [RRA_SET_LDFLAGS([CURL_LDFLAGS], [$rra_curl_root])])])
  AS_IF([test x"$rra_curl_includedir" != x],
-    [CURL_CPPFLAGS="-I$rra_curl_includedir"],
+    [CURL_CPPFLAGS="-isystem $rra_curl_includedir"],
     [AS_IF([test x"$rra_curl_root" != x],
         [AS_IF([test x"$rra_curl_root" != x/usr],
-            [CURL_CPPFLAGS="-I${rra_curl_root}/include"])])])])
+            [CURL_CPPFLAGS="-isystem ${rra_curl_root}/include"])])])])
 
 dnl Does the appropriate library checks for reduced-dependency cURL linkage.
 AC_DEFUN([_RRA_LIB_CURL_REDUCED],

--- a/m4/gssapi.m4
+++ b/m4/gssapi.m4
@@ -21,6 +21,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2005-2009, 2011-2012
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -68,10 +69,10 @@ AC_DEFUN([_RRA_LIB_GSSAPI_PATHS],
     [AS_IF([test x"$rra_gssapi_root" != x],
         [RRA_SET_LDFLAGS([GSSAPI_LDFLAGS], [$rra_gssapi_root])])])
  AS_IF([test x"$rra_gssapi_includedir" != x],
-    [GSSAPI_CPPFLAGS="-I$rra_gssapi_includedir"],
+    [GSSAPI_CPPFLAGS="-isystem $rra_gssapi_includedir"],
     [AS_IF([test x"$rra_gssapi_root" != x],
         [AS_IF([test x"$rra_gssapi_root" != x/usr],
-            [GSSAPI_CPPFLAGS="-I${rra_gssapi_root}/include"])])])])
+            [GSSAPI_CPPFLAGS="-isystem ${rra_gssapi_root}/include"])])])])
 
 dnl Does the appropriate library checks for reduced-dependency GSS-API
 dnl linkage.

--- a/m4/kafs.m4
+++ b/m4/kafs.m4
@@ -37,7 +37,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
-dnl Copyright 2020-2022 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2020-2021, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2008-2010
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -75,20 +75,21 @@ AC_DEFUN([_RRA_LIB_KAFS_PATHS],
     [AS_IF([test x"$rra_kafs_root" != x],
         [RRA_SET_LDFLAGS([KAFS_LDFLAGS], [$rra_kafs_root])])])
  AS_IF([test x"$rra_kafs_includedir" != x],
-    [KAFS_CPPFLAGS="-I$rra_kafs_includedir"],
+    [KAFS_CPPFLAGS="-isystem $rra_kafs_includedir"],
     [AS_IF([test x"$rra_kafs_root" != x],
         [AS_IF([test x"$rra_kafs_root" != x/usr],
-            [KAFS_CPPFLAGS="-I${rra_kafs_root}/include"])])])
+            [KAFS_CPPFLAGS="-isystem ${rra_kafs_root}/include"])])])
  AS_IF([test x"$rra_afs_libdir" != x],
     [KAFS_LDFLAGS="$KAFS_LDFLAGS -L$rra_afs_libdir"],
     [AS_IF([test x"$rra_afs_root" != x],
         [RRA_SET_LDFLAGS([KAFS_LDFLAGS], [$rra_afs_root])])
          RRA_SET_LDFLAGS([KAFS_LDFLAGS], [$rra_afs_root], [afs])])
  AS_IF([test x"$rra_afs_includedir" != x],
-    [KAFS_CPPFLAGS="-I$rra_afs_includedir"],
+    [KAFS_CPPFLAGS="-isystem $rra_afs_includedir"],
     [AS_IF([test x"$rra_afs_root" != x],
         [AS_IF([test x"$rra_afs_root" != x/usr],
-            [KAFS_CPPFLAGS="$KAFS_CPPFLAGS -I${rra_afs_root}/include"])])])])
+            [KAFS_CPPFLAGS="$KAFS_CPPFLAGS \
+                -isystem ${rra_afs_root}/include"])])])])
 
 dnl Probe for lsetpag in the AFS libraries.  This is required on AIX and IRIX
 dnl since we can't use the regular syscall interface there.

--- a/m4/ldap.m4
+++ b/m4/ldap.m4
@@ -18,6 +18,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2010
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -53,10 +54,10 @@ AC_DEFUN([_RRA_LIB_LDAP_PATHS],
     [AS_IF([test x"$rra_ldap_root" != x],
         [RRA_SET_LDFLAGS([LDAP_LDFLAGS], [$rra_ldap_root])])])
  AS_IF([test x"$rra_ldap_includedir" != x],
-    [LDAP_CPPFLAGS="-I$rra_ldap_includedir"],
+    [LDAP_CPPFLAGS="-isystem $rra_ldap_includedir"],
     [AS_IF([test x"$rra_ldap_root" != x],
         [AS_IF([test x"$rra_ldap_root" != x/usr],
-            [LDAP_CPPFLAGS="-I${rra_ldap_root}/include"])])])])
+            [LDAP_CPPFLAGS="-isystem ${rra_ldap_root}/include"])])])])
 
 dnl The main macro.
 AC_DEFUN([RRA_LIB_LDAP],

--- a/m4/lib-helper.m4
+++ b/m4/lib-helper.m4
@@ -14,7 +14,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
-dnl Copyright 2018 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2018, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2011, 2013
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -57,10 +57,10 @@ AC_DEFUN([RRA_LIB_HELPER_PATHS],
     [AS_IF([test x"$rra_$1[]_root" != x],
         [RRA_SET_LDFLAGS([$1][_LDFLAGS], [${rra_$1[]_root}])])])
  AS_IF([test x"$rra_$1[]_includedir" != x],
-    [$1[]_CPPFLAGS="-I$rra_$1[]_includedir"],
+    [$1[]_CPPFLAGS="-isystem $rra_$1[]_includedir"],
     [AS_IF([test x"$rra_$1[]_root" != x],
         [AS_IF([test x"$rra_$1[]_root" != x/usr],
-            [$1[]_CPPFLAGS="-I${rra_$1[]_root}/include"])])])])
+            [$1[]_CPPFLAGS="-isystem ${rra_$1[]_root}/include"])])])])
 
 dnl Check whether a library works.  This is used as a sanity check on the
 dnl results of *-config shell scripts.  Takes four arguments; the first, if

--- a/m4/pcre.m4
+++ b/m4/pcre.m4
@@ -22,7 +22,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
-dnl Copyright 2021-2022 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2021-2022, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2010, 2013
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -58,10 +58,10 @@ AC_DEFUN([_RRA_LIB_PCRE_PATHS],
     [AS_IF([test x"$rra_pcre_root" != x],
         [RRA_SET_LDFLAGS([PCRE_LDFLAGS], [$rra_pcre_root])])])
  AS_IF([test x"$rra_pcre_includedir" != x],
-    [PCRE_CPPFLAGS="-I$rra_pcre_includedir"],
+    [PCRE_CPPFLAGS="-isystem $rra_pcre_includedir"],
     [AS_IF([test x"$rra_pcre_root" != x],
         [AS_IF([test x"$rra_pcre_root" != x/usr],
-            [PCRE_CPPFLAGS="-I${rra_pcre_root}/include"])])])])
+            [PCRE_CPPFLAGS="-isystem ${rra_pcre_root}/include"])])])])
 
 dnl Does the appropriate library checks for PCRE linkage without pcre-config.
 dnl The single argument, if true, says to fail if PCRE could not be found.

--- a/m4/perl.m4
+++ b/m4/perl.m4
@@ -27,7 +27,7 @@ dnl
 dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
-dnl Copyright 2016, 2018, 2021-2022 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2016, 2018, 2021-2022, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2006, 2009, 2011 Internet Systems Consortium, Inc. ("ISC")
 dnl Copyright 1998-2003 The Internet Software Consortium
 dnl
@@ -92,6 +92,8 @@ AC_DEFUN([RRA_LIB_PERL],
  AC_MSG_CHECKING([for flags to link with Perl])
  rra_perl_core_path=`"$PERL" -MConfig -e 'print $Config{archlibexp}'`
  rra_perl_core_flags=`"$PERL" -MExtUtils::Embed -e ccopts`
+ rra_perl_core_flags=`AS_ECHO(["$rra_perl_core_flags"]) \
+    | sed 's% -I/% -isystem /%g'`
  rra_perl_core_libs=`"$PERL" -MExtUtils::Embed -e ldopts 2>&1 | tail -n 1`
  rra_perl_core_libs=" $rra_perl_core_libs "
  rra_perl_core_libs=`AS_ECHO(["$rra_perl_core_libs"]) | sed 's/ -lc / /'`

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -132,20 +132,24 @@ AC_DEFUN([RRA_LIB_PYTHON],
         print(" -L".join(sysconfig.get_config_vars("LIBDIR")))'`
      py_ldlibrary=`$PYTHON -c 'import sysconfig; \
         print(sysconfig.get_config_vars("LDLIBRARY")@<:@0@:>@)'`
-     py_linkage=`$PYTHON -c 'import sysconfig;                     \
-        print(" ".join(sysconfig.get_config_vars(                  \
-            "LIBS", "LIBC", "LIBM", "LOCALMODLIBS", "BASEMODLIBS", \
-            "LINKFORSHARED", "LDFLAGS")))'`],
+     AS_IF([test -x "${PYTHON}-config"],
+        [py_linkage=`${PYTHON}-config --libs 2>/dev/null`],
+        [py_linkage=`$PYTHON -c 'import sysconfig;     \
+            print(" ".join(sysconfig.get_config_vars(  \
+                "LIBS", "LIBC", "LIBM", "BASEMODLIBS", \
+                "LINKFORSHARED", "LDFLAGS")))'`])],
     [py_include=`$PYTHON -c 'import distutils.sysconfig; \
         print(distutils.sysconfig.get_python_inc())'`
      py_libdir=`$PYTHON -c 'import distutils.sysconfig; \
         print(" -L".join(distutils.sysconfig.get_config_vars("LIBDIR")))'`
      py_ldlibrary=`$PYTHON -c 'import distutils.sysconfig; \
         print(distutils.sysconfig.get_config_vars("LDLIBRARY")@<:@0@:>@)'`
-     py_linkage=`$PYTHON -c 'import distutils.sysconfig;           \
-        print(" ".join(distutils.sysconfig.get_config_vars(        \
-            "LIBS", "LIBC", "LIBM", "LOCALMODLIBS", "BASEMODLIBS", \
-            "LINKFORSHARED", "LDFLAGS")))'`])
+     AS_IF([test -x "${PYTHON}-config"],
+        [py_linkage=`${PYTHON}-config --libs 2>/dev/null`],
+        [py_linkage=`$PYTHON -c 'import distutils.sysconfig;    \
+            print(" ".join(distutils.sysconfig.get_config_vars( \
+                "LIBS", "LIBC", "LIBM", "BASEMODLIBS",          \
+                "LINKFORSHARED", "LDFLAGS")))'`])])
  PYTHON_CPPFLAGS="-isystem $py_include"
  py_libpython=`AS_ECHO(["$py_ldlibrary"]) \
     | sed -e 's/^lib//' -e 's/\.@<:@a-z@:>@*$//'`

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -42,7 +42,7 @@ dnl
 dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
-dnl Copyright 2018, 2021-2022 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2018, 2021-2022, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2009, 2011, 2015, 2018, 2021
 dnl     Julien ÉLIE <julien@trigofacile.com>
 dnl Copyright 1998-2003 The Internet Software Consortium
@@ -146,7 +146,7 @@ AC_DEFUN([RRA_LIB_PYTHON],
         print(" ".join(distutils.sysconfig.get_config_vars(        \
             "LIBS", "LIBC", "LIBM", "LOCALMODLIBS", "BASEMODLIBS", \
             "LINKFORSHARED", "LDFLAGS")))'`])
- PYTHON_CPPFLAGS="-I$py_include"
+ PYTHON_CPPFLAGS="-isystem $py_include"
  py_libpython=`AS_ECHO(["$py_ldlibrary"]) \
     | sed -e 's/^lib//' -e 's/\.@<:@a-z@:>@*$//'`
  PYTHON_LIBS="-L$py_libdir -l$py_libpython $py_linkage"

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -112,7 +112,7 @@ dnl Check whether a given Python module can be loaded.  Runs the second
 dnl argument if it can, and the third argument if it cannot.
 AC_DEFUN([RRA_PYTHON_CHECK_MODULE],
 [AS_LITERAL_IF([$1], [], [m4_fatal([$0: requires literal arguments])])dnl
- AS_VAR_PUSHDEF([ac_Module], [inn_cv_python_module_$1])dnl
+ AS_VAR_PUSHDEF([ac_Module], [rra_cv_python_module_$1])dnl
  AC_CACHE_CHECK([for Python module $1], [ac_Module],
     [AS_IF(["$PYTHON" -c 'import $1' >/dev/null 2>&1],
         [AS_VAR_SET([ac_Module], [yes])],

--- a/m4/remctl.m4
+++ b/m4/remctl.m4
@@ -29,7 +29,7 @@ dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
 dnl Written by Russ Allbery <eagle@eyrie.org>
-dnl Coypright 2022 Russ Allbery <eagle@eyrie.org>
+dnl Coypright 2022, 2024 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2008-2009, 2011, 2013
 dnl     The Board of Trustees of the Leland Stanford Junior University
 dnl
@@ -65,10 +65,10 @@ AC_DEFUN([_RRA_LIB_REMCTL_PATHS],
     [AS_IF([test x"$rra_remctl_root" != x],
         [RRA_SET_LDFLAGS([REMCTL_LDFLAGS], [$rra_remctl_root])])])
  AS_IF([test x"$rra_remctl_includedir" != x],
-    [REMCTL_CPPFLAGS="-I$rra_remctl_includedir"],
+    [REMCTL_CPPFLAGS="-isystem $rra_remctl_includedir"],
     [AS_IF([test x"$rra_remctl_root" != x],
         [AS_IF([test x"$rra_remctl_root" != x/usr],
-            [REMCTL_CPPFLAGS="-I${rra_remctl_root}/include"])])])])
+            [REMCTL_CPPFLAGS="-isystem ${rra_remctl_root}/include"])])])])
 
 dnl Sanity-check the results of the remctl library search to be sure we can
 dnl really link a remctl program.


### PR DESCRIPTION
It suppresses unwanted warnings from included header files when building applications.