### PR TITLE
Fix build failures and warnings with current versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 # Workflow for GitHub Actions testing.
 #
-# Copyright 2015-2020, 2022 Russ Allbery <eagle@eyrie.org>
+# Copyright 2015-2020, 2022, 2025 Russ Allbery <eagle@eyrie.org>
 #
 # SPDX-License-Identifier: MIT
 
@@ -9,12 +9,12 @@ name: build
 on:
   push:
     branches:
-      - "*"
+      - "main"
     tags:
       - "release/*"
   pull_request:
     branches:
-      - main
+      - "main"
 
 jobs:
   build:

--- a/changelog.d/20250810_100345_eagle_update_ci.md
+++ b/changelog.d/20250810_100345_eagle_update_ci.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix null pointer dereference on memory allocation failure in the vector support library for PAM modules.

--- a/changelog.d/20250810_101611_eagle_update_ci.md
+++ b/changelog.d/20250810_101611_eagle_update_ci.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add `-Wno-switch-default` to the default Clang warning flags in `RRA_PROG_CC_WARNINGS_FLAGS`. Clang 19 enables `-Wswitch-default` with `-Weverything`, but it produces false positives for switches on enums where all enum members are covered.

--- a/m4/cc-flags.m4
+++ b/m4/cc-flags.m4
@@ -1,4 +1,4 @@
-# serial 2
+# serial 3
 
 dnl Check whether the compiler supports particular flags.
 dnl
@@ -17,7 +17,7 @@ dnl
 dnl The canonical version of this file is maintained in the rra-c-util
 dnl package, available at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 dnl
-dnl Copyright 2016-2024 Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2016-2025 Russ Allbery <eagle@eyrie.org>
 dnl Copyright 2006, 2009, 2016
 dnl     by Internet Systems Consortium, Inc. ("ISC")
 dnl
@@ -116,9 +116,10 @@ AC_DEFUN([RRA_PROG_CC_WARNINGS_FLAGS],
      m4_foreach_w([flag],
         [-Weverything -Wno-cast-qual -Wno-disabled-macro-expansion -Wno-padded
          -Wno-sign-conversion -Wno-reserved-id-macro -Wno-reserved-identifier
-         -Wno-tautological-pointer-compare -Wno-undef -Wno-unreachable-code
-         -Wno-unreachable-code-return -Wno-unsafe-buffer-usage
-         -Wno-unused-macros -Wno-used-but-marked-unused],
+         -Wno-switch-default -Wno-tautological-pointer-compare -Wno-undef
+         -Wno-unreachable-code -Wno-unreachable-code-return
+         -Wno-unsafe-buffer-usage -Wno-unused-macros
+         -Wno-used-but-marked-unused],
         [RRA_PROG_CC_FLAG(flag,
             [WARNINGS_CFLAGS="${WARNINGS_CFLAGS} flag"])])],
     [WARNINGS_CFLAGS="-g -O2 -D_FORTIFY_SOURCE=2 -Werror"

--- a/pam-util/vector.c
+++ b/pam-util/vector.c
@@ -21,7 +21,7 @@
  * which can be found at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
  *
  * Written by Russ Allbery <eagle@eyrie.org>
- * Copyright 2017-2018 Russ Allbery <eagle@eyrie.org>
+ * Copyright 2017-2018, 2025 Russ Allbery <eagle@eyrie.org>
  * Copyright 2010-2011, 2014
  *     The Board of Trustees of the Leland Stanford Junior University
  *
@@ -48,8 +48,14 @@ vector_new(void)
     struct vector *vector;
 
     vector = calloc(1, sizeof(struct vector));
+    if (vector == NULL)
+        return NULL;
     vector->allocated = 1;
     vector->strings = calloc(1, sizeof(char *));
+    if (vector->strings == NULL) {
+        free(vector);
+        return NULL;
+    }
     return vector;
 }
 

--- a/portable/getaddrinfo.c
+++ b/portable/getaddrinfo.c
@@ -20,7 +20,8 @@
  * which can be found at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
  *
  * Written by Russ Allbery <eagle@eyrie.org>
- * Copyright 2003-2005, 2016-2017, 2019-2020 Russ Allbery <eagle@eyrie.org>
+ * Copyright 2003-2005, 2016-2017, 2019-2020, 2025
+ *     Russ Allbery <eagle@eyrie.org>
  * Copyright 2015 Julien ÉLIE <julien@trigofacile.com>
  * Copyright 2008, 2011, 2013-2014
  *     The Board of Trustees of the Leland Stanford Junior University
@@ -120,13 +121,6 @@ static const char *const gai_errors[] = {
     "System error",                     /*  9 EAI_SYSTEM */
     "Supplied buffer too small",        /* 10 EAI_OVERFLOW */
 };
-
-/* Macro to set the len attribute of sockaddr_in. */
-#if HAVE_STRUCT_SOCKADDR_SA_LEN
-#    define sin_set_length(s) ((s)->sin_len = sizeof(struct sockaddr_in))
-#else
-#    define sin_set_length(s) /* empty */
-#endif
 
 /*
  * Used for iterating through arrays.  ARRAY_SIZE returns the number of
@@ -230,7 +224,9 @@ gai_addrinfo_new(int socktype, const char *canonical, struct in_addr addr,
     sin->sin_family = AF_INET;
     sin->sin_addr = addr;
     sin->sin_port = htons(port);
-    sin_set_length(sin);
+#if HAVE_STRUCT_SOCKADDR_SA_LEN
+    sin->sin_len = sizeof(struct sockaddr_in);
+#endif
     ai->ai_addr = (struct sockaddr *) sin;
     ai->ai_addrlen = sizeof(struct sockaddr_in);
     return ai;

--- a/tests/data/perlcriticrc
+++ b/tests/data/perlcriticrc
@@ -10,7 +10,7 @@
 # which can be found at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
 #
 # Written by Russ Allbery <eagle@eyrie.org>
-# Copyright 2018-2022 Russ Allbery <eagle@eyrie.org>
+# Copyright 2018-2022, 2025 Russ Allbery <eagle@eyrie.org>
 # Copyright 2011-2013
 #     The Board of Trustees of the Leland Stanford Junior University
 #
@@ -46,11 +46,7 @@ verbose  = %f:%l:%c: [%p] %m (%e, Severity: %s)\n
 # Subroutines::RequireFinalReturn, and I prefer the brevity of the simple
 # return statement.  I don't think the empty list versus undef behavior is
 # that confusing.
-#
-# This should be Community::EmptyReturn, which is the new name of the module,
-# but currently ignores have to use the Freenode::EmptyReturn name instead.
 [-Community::EmptyReturn]
-[-Freenode::EmptyReturn]
 
 # This recommends using given/when, but Perl has marked those as experimental
 # and cautions against using when.


### PR DESCRIPTION
- Drop now-unneeded perlcritic exclusion.
- Fix null pointer dereference in pam-util vector library on memory allocation failure.
- Fix cppcheck false positive in `portable/getaddrinfo.c`.
- Add `-Wno-switch-default` to Clang warning flags.