### PR TITLE
Enable the References::ProhibitDoubleSigils perlcritic policy

### DIFF
--- a/changelog.d/20250810_114220_eagle_perlcritic.md
+++ b/changelog.d/20250810_114220_eagle_perlcritic.md
@@ -1,0 +1,3 @@
+### New features
+
+- Enable the `References::ProhibitDoubleSigils` perlcritic policy. The bug with postfix dereferencing was fixed in perlcritic 1.142. (GitHub #19)

--- a/ci/apt-packages
+++ b/ci/apt-packages
@@ -3,12 +3,13 @@
 # This file is read by ci/install and used as a list of packages, one per
 # line, to install for testing.
 #
-# Copyright 2015-2021 Russ Allbery <eagle@eyrie.org>
+# Copyright 2015-2021, 2025 Russ Allbery <eagle@eyrie.org>
 #
 # SPDX-License-Identifier: MIT
 
 cpanminus
 cppcheck
+hunspell
 libevent-dev
 libkrb5-dev
 libpam0g-dev

--- a/ci/cpanfile
+++ b/ci/cpanfile
@@ -3,14 +3,16 @@
 # This file is used by cpanm to install dependencies used by the rra-c-util
 # test suite.
 #
-# Copyright 2015-2020, 2022 Russ Allbery <eagle@eyrie.org>
+# Copyright 2015-2020, 2022, 2025 Russ Allbery <eagle@eyrie.org>
 #
 # SPDX-License-Identifier: MIT
 
 on 'test' => sub {
     suggests 'Devel::Cover';
     suggests 'IPC::System::Simple';
+    suggests 'Perl6::Slurp';
     suggests 'Perl::Critic::Community';
+    suggests 'Test::Kwalitee';
     suggests 'Test::MinimumVersion';
     suggests 'Test::Perl::Critic';
     suggests 'Test::Pod';

--- a/ci/test
+++ b/ci/test
@@ -5,7 +5,7 @@
 # This script is normally run in a test container or VM, such as via GitHub
 # Actions.
 #
-# Copyright 2015-2020, 2024 Russ Allbery <eagle@eyrie.org>
+# Copyright 2015-2020, 2024-2025 Russ Allbery <eagle@eyrie.org>
 #
 # SPDX-License-Identifier: MIT
 
@@ -23,6 +23,9 @@ make warnings
 make distclean
 ./configure CC=gcc
 make warnings
+
+# Run the test suite including for the Perl helpers.
+make check
 
 # Test with valgrind.
 make check-valgrind

--- a/m4/cc-flags.m4
+++ b/m4/cc-flags.m4
@@ -100,6 +100,7 @@ dnl   -Wpadded                        Not an actual problem
 dnl   -Wreserved-id-macro             Autoconf sets several of these normally
 dnl   -Wreserved-identifer            False positive with FD_ZERO
 dnl   -Wsign-conversion               Too many fiddly changes for the benefit
+dnl   -Wswitch-default                False positives with switches on enums
 dnl   -Wtautological-pointer-compare  False positives with for loops
 dnl   -Wundef                         Conflicts with Autoconf probe results
 dnl   -Wunreachable-code              Happens with optional compilation

--- a/tests/data/perlcriticrc
+++ b/tests/data/perlcriticrc
@@ -1,6 +1,6 @@
 # -*- conf -*-
 #
-# Default configuration for perlcritic.  Be sure to copy this into the source
+# Default configuration for perlcritic. Be sure to copy this into the source
 # for packages that run perlcritic tests automatically during the build for
 # reproducible test results.
 #
@@ -14,45 +14,46 @@
 # Copyright 2011-2013
 #     The Board of Trustees of the Leland Stanford Junior University
 #
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #
 # SPDX-License-Identifier: MIT
 
 severity = 1
 verbose  = %f:%l:%c: [%p] %m (%e, Severity: %s)\n
 
-# I prefer this policy (a lot, actually), but other people in my group at
-# Stanford really didn't like it, so this is my compromise to agree with a
-# group coding style.
+# Originally I preferred this style, but I have been convinced that it's less
+# readable for people coming from other languages and poses more tricky
+# precedence problems. I've now gotten used to using parentheses for
+# everything.
 [-CodeLayout::ProhibitParensWithBuiltins]
 
 # This conflicts with Subroutines::ProhibitExplicitReturnUndef and
 # Subroutines::RequireFinalReturn, and I prefer the brevity of the simple
-# return statement.  I don't think the empty list versus undef behavior is
-# that confusing.
+# return statement. I don't think the empty list versus undef behavior is that
+# confusing.
 [-Community::EmptyReturn]
 
 # This recommends using given/when, but Perl has marked those as experimental
 # and cautions against using when.
 [-ControlStructures::ProhibitCascadingIfElse]
 
-# Stanford's coding style allows postfix unless for flow control.  There
+# Stanford's coding style allows postfix unless for flow control. There
 # doesn't appear to be any way to allow it only for flow control (the logic
 # for "if" and "when" appears to be special-cased), so we have to allow unless
 # globally.
@@ -70,7 +71,7 @@ allow = unless
 # of $@ even if destructors run at exit from the eval block.
 [-ErrorHandling::RequireCheckingReturnValueOfEval]
 
-# The default of 9 is too small and forces weird code contortions.  After some
+# The default of 9 is too small and forces weird code contortions. After some
 # experimentation, I've never found this helpful in driving useful refactors.
 [-InputOutput::RequireBriefOpen]
 
@@ -80,18 +81,13 @@ allow = unless
 # globally.
 [-Modules::RequireVersionVar]
 
-# This sounds interesting but is actually useless.  Any large blocks of
-# literal text, which does not add to the complexity of the regex, will set it
-# off.
+# This sounds interesting but is actually useless. Any large blocks of literal
+# text, which does not add to the complexity of the regex, will set it off.
 [-RegularExpressions::ProhibitComplexRegexes]
 
-# Produces false positives currently with postfix dereferencing (introduced in
-# Perl 5.20).  See https://github.com/Perl-Critic/Perl-Critic/issues/578.
-[-References::ProhibitDoubleSigils]
-
 # Five arguments to a method has seemed reasonable at least once: a pair of
-# input file data and path, a pair of output file descriptor and path, and
-# a dict of additional arguments.
+# input file data and path, a pair of output file descriptor and path, and a
+# dict of additional arguments.
 [Subroutines::ProhibitManyArgs]
 skip_object = 1
 
@@ -100,7 +96,7 @@ skip_object = 1
 [-ValuesAndExpressions::ProhibitConstantPragma]
 
 # A good idea, but there are too many places where this would be more
-# confusing than helpful.  Pull out numbers if one might change them
+# confusing than helpful. Pull out numbers if one might change them
 # independent of the algorithm, but don't do so for mathematical formulae.
 [-ValuesAndExpressions::ProhibitMagicNumbers]
 
@@ -114,7 +110,7 @@ skip_object = 1
 [Variables::ProhibitPackageVars]
 add_packages = IO::Uncompress::Gunzip Text::Wrap YAML::XS
 
-# use English was one of the worst ideas in the history of Perl.  It makes the
+# use English was one of the worst ideas in the history of Perl. It makes the
 # code slightly more readable for amateurs at the cost of confusing
 # experienced Perl programmers and sending people in futile quests for where
 # these magical global variables are defined.


### PR DESCRIPTION
The perlcritic bug preventing the use of this policy was fixed in perlcritic 1.142.

Fixes #19